### PR TITLE
Update recurly config

### DIFF
--- a/app/initializers/recurly-service.js
+++ b/app/initializers/recurly-service.js
@@ -5,7 +5,10 @@ export function initialize(container, application) {
   if(!config.recurly.publicKey) {
     throw new Ember.Error('RecurlyService: Missing Recurly key, please set `ENV.recurly.publicKey` in config.environment.js');
   }
-  recurly.configure(config.recurly.publicKey);
+
+  if (window.recurly) {
+    recurly.configure(config.recurly.publicKey);
+  }
 }
 
 export default {

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -45,5 +45,58 @@ export default (Ember.Service || Ember.Object).extend({
         }
       });
     });
+  },
+
+  getPricing: function(
+    plan,
+    planQuantity,
+    currency,
+    addons,
+    coupon,
+    giftCard,
+    country,
+    postalCode,
+    taxCode,
+    vatNumber
+    ){
+
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+
+      let pricing = recurly.Pricing()
+
+      pricing = pricing
+        .plan(plan, planQuantity)
+        .currency(currency)
+
+      addons.forEach(function (addon) {
+        pricing.addon(addon.name, { quantity: addon.quantity });
+      });
+
+      if (coupon != null) {
+        pricing.coupon(coupon);
+      }
+
+      if (giftCard != null) {
+        pricing.giftcard(giftCard);
+      }
+
+      pricing
+        .address({
+          country: country,
+          postal_code: postalCode
+        })
+        .tax({
+          tax_code: taxCode,
+          vat_number: vatNumber
+        })
+        .catch(function(err){
+          reject(err);
+        })
+        .done(function(price){
+          resolve(price)
+        })
+
+        return pricing;
+      })
   }
 });

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -33,12 +33,16 @@ export default (Ember.Service || Ember.Object).extend({
     });
   },
 
-  payPal: function(opts) {
+  /* Valid options are: braintree and description.
+   * See https://dev.recurly.com/docs/paypal#section-recurlypaypal
+   * for more details.
+   */
+  payPal: function(options) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      const paypal = recurly.PayPal();
+      const paypal = recurly.PayPal(options);
       paypal.on('token', resolve);
       paypal.on('error', reject);
-      paypal.start();
+      paypal.start(options);
     });
   },
 

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -70,15 +70,20 @@ export default (Ember.Service || Ember.Object).extend({
         pricing.giftcard(options.giftCard);
       }
 
-      pricing
-        .address({
-          country: country,
-          postal_code: postalCode
-        })
-        .tax({
-          tax_code: taxCode,
-          vat_number: vatNumber
-        })
+      if (options.country && options.postalCode) {
+        pricing.address({
+          country: options.country,
+          postal_code: options.postalCode
+        });
+
+      }
+
+      if (options.taxCode || options.vatNumber) {
+        pricing.tax({
+          tax_code: options.taxCode,
+          vat_number: options.vatNumber
+        });
+      }
 
       return pricing
         .catch(function(err){

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -34,16 +34,11 @@ export default (Ember.Service || Ember.Object).extend({
   },
 
   payPal: function(opts) {
-    let self = this;
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      recurly.paypal(opts, function(err, token) {
-        if(err) {
-          reject(err);
-        } else {
-          self.set('token', token);
-          resolve(token);
-        }
-      });
+      const paypal = recurly.PayPal();
+      paypal.on('token', resolve);
+      paypal.on('error', reject);
+      paypal.start();
     });
   },
 

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -47,37 +47,27 @@ export default (Ember.Service || Ember.Object).extend({
     });
   },
 
-  getPricing: function(
-    plan,
-    planQuantity,
-    currency,
-    addons,
-    coupon,
-    giftCard,
-    country,
-    postalCode,
-    taxCode,
-    vatNumber
-    ){
-
+  /* Valid options are: plan, planQuantity, currency, addons,
+   * coupon, giftCard, country, postalCode, taxCode, vatNumber.
+   * See https://dev.recurly.com/docs/pricing#section-input-elements
+   * for more details.
+   */
+  getPricing: function(options) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
-
       let pricing = recurly.Pricing()
+        .plan(options.plan, options.planQuantity)
+        .currency(options.currency)
 
-      pricing = pricing
-        .plan(plan, planQuantity)
-        .currency(currency)
-
-      addons.forEach(function (addon) {
+      options.addons.forEach(function (addon) {
         pricing.addon(addon.name, { quantity: addon.quantity });
       });
 
-      if (coupon != null) {
-        pricing.coupon(coupon);
+      if (options.coupon) {
+        pricing.coupon(options.coupon);
       }
 
-      if (giftCard != null) {
-        pricing.giftcard(giftCard);
+      if (options.giftCard) {
+        pricing.giftcard(options.giftCard);
       }
 
       pricing
@@ -89,14 +79,14 @@ export default (Ember.Service || Ember.Object).extend({
           tax_code: taxCode,
           vat_number: vatNumber
         })
+
+      return pricing
         .catch(function(err){
           reject(err);
         })
         .done(function(price){
           resolve(price)
-        })
-
-        return pricing;
-      })
+        });
+    });
   }
 });

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -107,20 +107,5 @@ export default (Ember.Service || Ember.Object).extend({
     recurly.parent();
   },
 
-  config: {
-    fields: Ember.computed({
-      get() {
-        return recurly.config.fields;
-      },
-
-      set(key, value) {
-        Object.keys(value).forEach((key) => {
-          recurly.config.fields[key] = Object.assign(
-            recurly.config.fields[key], value[key]
-          );
-        });
-        return recurly.config.fields;
-      }
-    })
-  }
+  config: Ember.computed(() => recurly.config)
 });

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -88,5 +88,34 @@ export default (Ember.Service || Ember.Object).extend({
           resolve(price)
         });
     });
+  },
+
+  on: function(event, callback) {
+    recurly.on(event, callback);
+  },
+
+  off: function(event) {
+    recurly.off(event);
+  },
+
+  parent: function() {
+    recurly.parent();
+  },
+
+  config: {
+    fields: Ember.computed({
+      get() {
+        return recurly.config.fields;
+      },
+
+      set(key, value) {
+        Object.keys(value).forEach((key) => {
+          recurly.config.fields[key] = Object.assign(
+            recurly.config.fields[key], value[key]
+          );
+        });
+        return recurly.config.fields;
+      }
+    })
   }
 });

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -70,7 +70,7 @@ export default (Ember.Service || Ember.Object).extend({
         pricing.giftcard(options.giftCard);
       }
 
-      if (options.country && options.postalCode) {
+      if (options.country || options.postalCode) {
         pricing.address({
           country: options.country,
           postal_code: options.postalCode

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -42,6 +42,7 @@ export default (Ember.Service || Ember.Object).extend({
       const paypal = recurly.PayPal(options);
       paypal.on('token', resolve);
       paypal.on('error', reject);
+      paypal.on('cancel', reject);
       paypal.start(options);
     });
   },

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   contentFor: function(type) {
     // we use body since Recurly must be available before
     if (type === 'body') {
-      return '<script type="text/javascript" src="https://js.recurly.com/v3/recurly.js"></script>';
+      return '<script type="text/javascript" src="https://js.recurly.com/v4/recurly.js"></script>';
     }
   }
 };


### PR DESCRIPTION
After updating our app to Ember v3.6, the getter and setter for `recurly.config.fields` was no longer working as expected. This PR simplifies the recurly config access. Now, to change the style for recurly fields for example, just get the config object and modify it:
```js
const config = this.get('recurly.config');
config.fields.all.style = { color: 'red' };
```